### PR TITLE
Add missing header for musl

### DIFF
--- a/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h
+++ b/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h
@@ -13,6 +13,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <cstdint>
 
 #include <string>
 


### PR DESCRIPTION
Fix compile on musl (e.g. Alpine).

This PR implements the following patch:
https://git.openembedded.org/meta-openembedded/commit/?id=3942953920b222bc1d901ddcd2cc23aa19e9e33e

It fixes the following error:

```
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DVERSION_INFO=1.2.3 -I/tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing -I/tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1 -I/tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/subprojects/abseil-cpp-20230125.1 -I/tmp/pip-build-env-rcn1j_ct/overlay/lib/python3.11/site-packages/pybind11/include -I/srv/homeassistant/include -I/usr/include/python3.11 -c -std=c++17 /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.cc -o build/temp.linux-armv7l-cpython-311/tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.o -fvisibility=hidden -g0 -DWEBRTC_LIBRARY_IMPL -DWEBRTC_ENABLE_SYMBOL_EXPORT -DNDEBUG -DWEBRTC_APM_DEBUG_DUMP=0 -D_GNU_SOURCE -DWEBRTC_LINUX -DWEBRTC_THREAD_RR -DWEBRTC_POSIX -DWEBRTC_ARCH_LITTLE_ENDIAN -DWEBRTC_ARCH_ARM_V7 -DWEBRTC_ARCH_ARM_FAMILY -DWEBRTC_ARCH_32_BITS -DWEBRTC_HAS_NEON -mfpu=neon
      In file included from /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.cc:11:
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:86:21: error: 'int64_t' has not been declared
         86 |   bool SeekRelative(int64_t offset);
            |                     ^~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:88:15: error: 'int64_t' has not been declared
         88 |   bool SeekTo(int64_t position);
            |               ^~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.cc:82:6: error: no declaration matches 'bool webrtc::FileWrapper::SeekRelative(int64_t)'
         82 | bool FileWrapper::SeekRelative(int64_t offset) {
            |      ^~~~~~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:86:8: note: candidate is: 'bool webrtc::FileWrapper::SeekRelative(int)'
         86 |   bool SeekRelative(int64_t offset);
            |        ^~~~~~~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:31:7: note: 'class webrtc::FileWrapper' defined here 
         31 | class FileWrapper final {
            |       ^~~~~~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.cc:87:6: error: no declaration matches 'bool webrtc::FileWrapper::SeekTo(int64_t)'
         87 | bool FileWrapper::SeekTo(int64_t position) {
            |      ^~~~~~~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:88:8: note: candidate is: 'bool webrtc::FileWrapper::SeekTo(int)'
         88 |   bool SeekTo(int64_t position);
            |        ^~~~~~
      /tmp/pip-install-_ndr6w89/webrtc-noise-gain_66cb2d7f3bd143479dc8c6ce5c2e2f31/webrtc-audio-processing/webrtc-audio-processing-1/rtc_base/system/file_wrapper.h:31:7: note: 'class webrtc::FileWrapper' defined here
         31 | class FileWrapper final {
            |       ^~~~~~~~~~~
      Traceback (most recent call last):
        File "/tmp/pip-build-env-rcn1j_ct/overlay/lib/python3.11/site-packages/setuptools/_distutils/unixccompiler.py", line 185, in _compile
          self.spawn(compiler_so + cc_args + [src, '-o', obj] + extra_postargs)
        File "/tmp/pip-build-env-rcn1j_ct/overlay/lib/python3.11/site-packages/setuptools/_distutils/ccompiler.py", line 1041, in spawn
          spawn(cmd, dry_run=self.dry_run, **kwargs)
        File "/tmp/pip-build-env-rcn1j_ct/overlay/lib/python3.11/site-packages/setuptools/_distutils/spawn.py", line 70, in spawn
          raise DistutilsExecError(
      setuptools._distutils.errors.DistutilsExecError: command '/usr/bin/gcc' failed with exit code 1
```