### PR TITLE
setup.py: Include other BSDs in elif clause matching freebsd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -380,7 +380,7 @@ elif system == "windows":
         "'-D_USE_MATH_DEFINES'",
     ]
     libraries += ["winmm"]
-elif system == "freebsd":
+elif system == 'dragonfly' or system == 'freebsd' or system == 'netbsd' or system == 'openbsd':
     system_cflags += ["-DWEBRTC_BSD", "-DWEBRTC_THREAD_RR", "-DWEBRTC_POSIX"]
 else:
     raise ValueError(f"Unsupported system: {system}")


### PR DESCRIPTION
This aligns with webrtc-audio-processing/meson.build.

With this, I can 'pip install' by giving my git checkout's path.