### PR TITLE
Build more wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,23 @@ on:
       - master
 
 jobs:
-  test_linux:
-    name: "linux test: ${{ matrix.arch }}"
-    runs-on: ubuntu-latest
+  test:
+    name: "Test: Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     strategy:
-      fail-fast: true
       matrix:
-        arch: [aarch64, armhf, armv7, amd64, i386]
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ "3.11", "3.12" ]
+        include:
+          - os: "macos-latest"
+            python-version: "native"
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        if: matrix.python-version != 'native' # To build cp312-cp312-macosx_14_0_arm64.whl
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: venv
         run: |
           python3 -m venv .venv
@@ -31,47 +39,3 @@ jobs:
         run: |
           .venv/bin/pip3 install pytest
           .venv/bin/pytest -vv tests
-  test_macos:
-    name: "macos test: ${{ matrix.arch }}"
-    runs-on: macos-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: venv
-        run: |
-          python3 -m venv .venv
-          .venv/bin/pip3 install --upgrade pip
-      - name: build
-        run: |
-          .venv/bin/pip3 wheel .
-      - name: install
-        run: |
-          .venv/bin/pip3 install --no-index -f . webrtc-noise-gain
-      - name: test
-        run: |
-          .venv/bin/pip3 install pytest
-          .venv/bin/pytest -vv tests
-  # test_windows:
-  #   name: "windows test: ${{ matrix.arch }}"
-  #   runs-on: windows-latest
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       arch: [amd64]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: venv
-  #       run: |
-  #         python3 -m venv .venv
-  #         .venv/scripts/pip3 install --upgrade pip
-  #     - name: build
-  #       run: |
-  #         .venv/scripts/pip3 wheel .
-  #     - name: install
-  #       run: |
-  #         .venv/scripts/pip3 install --no-index -f . webrtc-noise-gain
-  #     - name: test
-  #       run: |
-  #         .venv/scripts/pip3 install pytest
-  #         .venv/scripts/pytest -vv tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,20 +23,30 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
-  build_macos:
-    name: "macos build: ${{ matrix.arch }}"
-    runs-on: macos-latest
-    needs: create_release # we need to know the upload URL
+  build:
+    name: "Build: Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     strategy:
-      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ "3.11", "3.12" ]
+        include:
+          - os: "macos-latest"
+            python-version: "native"
+    runs-on: ${{ matrix.os }}
+    needs: create_release # we need to know the upload URL
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        if: matrix.python-version != 'native' # To build cp312-cp312-macosx_14_0_arm64.whl
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: venv
         run: |
           python3 -m venv .venv
           .venv/bin/pip3 install --upgrade pip
       - name: build
-        id: macos_wheel
+        id: wheel
         run: |
           .venv/bin/pip3 wheel .
           echo "wheel=$(ls *.whl)" > ${GITHUB_OUTPUT}
@@ -46,6 +56,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.macos_wheel.outputs.wheel }}
-          asset_name: ${{ steps.macos_wheel.outputs.wheel }}
+          asset_path: ${{ steps.wheel.outputs.wheel }}
+          asset_name: ${{ steps.wheel.outputs.wheel }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,14 +15,10 @@ jobs:
     steps:
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
+          generateReleaseNotes: true
+          makeLatest: true
   build:
     name: "Build: Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     strategy:
@@ -51,11 +47,7 @@ jobs:
           .venv/bin/pip3 wheel .
           echo "wheel=$(ls *.whl)" > ${GITHUB_OUTPUT}
       - name: upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: svenstaro/upload-release-action@v2
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.wheel.outputs.wheel }}
+          file: ${{ steps.wheel.outputs.wheel }}
           asset_name: ${{ steps.wheel.outputs.wheel }}
-          asset_content_type: application/octet-stream

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,6 @@ jobs:
           - os: "macos-latest"
             python-version: "native"
     runs-on: ${{ matrix.os }}
-    needs: create_release # we need to know the upload URL
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Build wheels for:
* `cp311-cp311-macosx_10_9_universal2`
* `cp312-cp312-macosx_10_9_universal2`
* `cp312-cp312-macosx_14_0_arm64`
* `cp311-cp311-linux_x86_64`
* `cp312-cp312-linux_x86_64`

Merged linux and macos jobs, as they can be controlled by the matrix.
Removed arch from the linux job, as it did not build on different architectures

See https://github.com/oyvindwe/webrtc-noise-gain/actions/runs/9981161290 for a run of the `test` workflow.

Also updated release actions to fix warnings. See https://github.com/oyvindwe/webrtc-noise-gain/actions/runs/10008601807 of a run of the `wheels` workflow with the result here: https://github.com/oyvindwe/webrtc-noise-gain/releases/tag/test-release-4